### PR TITLE
feat: adding option to create a metadata file in the same location as mrc output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [unreleased] -- 14 August 2025
+### Added
+- `metadata_handler.py`: new module housing `make_metadata_file` function.
+- `make_metadata_file`: utility to generate metadata with simulated volumes
+
 ## [v0.3.0] -- 17 June 2025
 
 ### Modified

--- a/src/ttsim3d/metadata_handler.py
+++ b/src/ttsim3d/metadata_handler.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+def make_metadata_file(
+        mrc_filepath: str, 
+        pdb_filepath: str,
+        added_b: float,
+        upsampling: int,
+        scaled_b: float, 
+        pixel_size: float, 
+        volume_size: tuple[int, int, int], 
+        centered: bool, 
+        dose_start: float, 
+        dose_end: float, 
+        voltage: float,
+) -> None:
+    """
+    Write the metadata file with simulator parameters in the same place as the final volume.
+    """
+    metadata_filepath = mrc_filepath.replace(".mrc", "_sim_parameters.txt")
+    with open(metadata_filepath, 'w') as f:
+        f.write("Simulator parameters:\n")
+        f.write(f"Time simulated: {datetime.now()}\n")
+        f.write(f"PDB filepath: {pdb_filepath}\n")
+        f.write(f"Output: {mrc_filepath}\n")
+        f.write(f"Voltage: {voltage:.2f}\n")
+        f.write(f"Dose start: {dose_start:.2f}\n")
+        f.write(f"Dose end: {dose_end:.2f}\n")
+        f.write(f"Upsampling: {upsampling}\n")
+        f.write(f"Volume size: {volume_size}\n")
+        f.write(f"Centered atoms?: {centered}\n")
+        f.write(f"Scaled b-factor: {scaled_b:.2f}\n")
+        f.write(f"Added b-factor: {added_b:.2f}\n")
+        f.write(f"Pixel size: {pixel_size:.4f}\n")


### PR DESCRIPTION
Adds an option to Simulator.export_to_mrc() to produce a metadata text file in the same location as the mrc file, which contains:
- The filepath to the volume and pdb file
- The added and scaled b-factor
- The pixel size and volume size of the simulated template
- Whether atoms are centered or not
- The dose start, end, and upsampling 
-  The voltage at which the simulator was run
### Rationale
I've already implemented this in my version of ttsim3d and I find it extremely helpful when generating multiple templates and troubleshooting 2DTM. For 2DTM, we have config files that serve as metadata, it's nice to have that option for the simulator coded in.