### PR TITLE
CLI bugfix for device specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,19 @@ volume_gpu = sim.run(device="cuda:0")
 # Same argument can be passed to the `export_to_mrc` method
 sim.export_to_mrc(mrc_filepath, device="cuda:0")
 ```
+
+## Included MTF reference files
+
+Users can specify MTF reference by a path to a star file under the `SimulatorConfig.mtf_reference` parameter.
+Applying a DQE filter during simulation can be turned on or off by the `SimulatorConfig.apply_dqe` parameter.
+
+The `ttsim3d` package includes several common MTF reference files which are accessible by a string rather than a path.
+To see the list of included MTF reference files, run the following code snippet:
+
+```python
+from ttsim3d import models
+
+print(models.included_mtf_references())
+```
+
+The default MTF reference is `"k2_300kV"`, which corresponds to the MTF of a Gatan K2 camera at 300 kV.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All options for the program can be printed by running:
 ttsim3d-cli --help
 ```
 
-The following are descriptions of each of the options for the program
+<!-- The following are descriptions of each of the options for the program
 
 
 | Option                        | Type                                  | Default       | Description                                                                                                                                                       |
@@ -60,14 +60,14 @@ The following are descriptions of each of the options for the program
 | `--dose-end`                  | float                                 | `30.0`        | The ending dose in e/A^2.
 | `--apply-dqe`                 | bool                                  | `True`        | If True, apply a DQE filter to the simulation.
 | `--mtf-reference`             | Path or str                           | `"k2_300kV"`  | Path to the modulation transfer function (MTF) reference star file, or one of the known MTF reference files. Default is 'k2_300kV'.
-| `--gpu-ids`                   | list[int]                             | unused        | A list of GPU IDs to use for the simulation. Currently unused.
+| `--device`                   | str                             | `"cpu"`        | The device to use for the simulation (e.g., "cpu" for CPU computation, or "cuda:0" or "0" for GPU computation on the zeroth device). -->
 
 ## Python objects
 
 There are two user-facing classes in `ttsim3d` built upon Pydantic models for validating inputs and simulating a volume.
 The first class, `ttsim3d.models.Simulator`, holds reference to a PDB file and basic simulation parameters related to that structure.
 The second class, `ttsim3d.models.SimulatorConfig` is used to configure more advanced options, such as dose weighting and simulation upsampling.
-An extremely basic use of these objects to run a simulation looks like
+An basic use of these objects to run a simulation looks like
 ```python
 from ttsim3d.models import Simulator, SimulatorConfig
 
@@ -98,4 +98,25 @@ print(volume.shape)  # (256, 256, 256)
 # OR export the simulation to a mrc file
 mrc_filepath = "some/path/to/simulated_structure/mrc"
 sim.export_to_mrc(mrc_filepath)
+```
+
+### Running on GPU or CPU
+
+The `ttsim3d` package supports GPU accelerated simulations with PyTorch.
+Use the `device` argument to specify which device to run the simulation on.
+
+```python
+# ...
+# Assume same objects as above
+
+# Run on the CPU
+volume_cpu = sim.run(device="cpu")
+
+# Run on the GPU (assumes CUDA is available)
+# Both run on the zeroth GPU device
+volume_gpu = sim.run(device="0")
+volume_gpu = sim.run(device="cuda:0")
+
+# Same argument can be passed to the `export_to_mrc` method
+sim.export_to_mrc(mrc_filepath, device="cuda:0")
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ description = "Simulate a 3D electrostatic potential map from a PDB in pyTorch"
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "BSD-3-Clause" }
-authors = [{ name = "Josh Dickerson", email = "jdickerson@berkeley.edu" }]
+authors = [
+    { name = "Josh Dickerson", email = "jdickerson@berkeley.edu" },
+    { name = "Matthew Giammar", email = "matthew_giammar@berkeley.edu" },
+]
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -61,9 +64,9 @@ test = ["pytest", "pytest-cov", "requests"]
 dev = [
     "ipython",
     "mypy",
-    "pdbpp",  # https://github.com/pdbpp/pdbpp
+    "pdbpp",      # https://github.com/pdbpp/pdbpp
     "pre-commit",
-    "rich",  # https://github.com/Textualize/rich
+    "rich",       # https://github.com/Textualize/rich
     "ruff",
 ]
 
@@ -114,7 +117,7 @@ ignore = [
 # https://docs.astral.sh/ruff/formatter/
 [tool.ruff.format]
 docstring-code-format = true
-skip-magic-trailing-comma = false  # default is false
+skip-magic-trailing-comma = false # default is false
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
@@ -156,8 +159,4 @@ source = ["ttsim3d"]
 # add files that you want check-manifest to explicitly ignore here
 # (files that are in the repo but shouldn't go in the package)
 [tool.check-manifest]
-ignore = [
-    ".pre-commit-config.yaml",
-    ".ruff_cache/**/*",
-    "tests/**/*",
-]
+ignore = [".pre-commit-config.yaml", ".ruff_cache/**/*", "tests/**/*"]

--- a/src/programs/run_ttsim3d.py
+++ b/src/programs/run_ttsim3d.py
@@ -111,7 +111,7 @@ from ttsim3d.models import Simulator, SimulatorConfig
 @click.option(
     "--mtf-reference",
     type=str,
-    default="k2_300kV_FL2",
+    default="k2_300kV",
     help=(
         "Path to the modulation transfer function (MTF) reference star "
         "file, or one of the known MTF reference files. "

--- a/src/programs/run_ttsim3d.py
+++ b/src/programs/run_ttsim3d.py
@@ -111,7 +111,7 @@ from ttsim3d.models import Simulator, SimulatorConfig
 @click.option(
     "--mtf-reference",
     type=str,
-    default="k2_300kV",
+    default="k2_300kV_FL2",
     help=(
         "Path to the modulation transfer function (MTF) reference star "
         "file, or one of the known MTF reference files. "
@@ -119,13 +119,13 @@ from ttsim3d.models import Simulator, SimulatorConfig
     ),
 )
 @click.option(
-    "--gpu-ids",
-    type=Union[int, list[int], str, list[str]],
-    multiple=True,
+    "--device",
+    type=str,
+    default="cpu",
     help=(
-        "A single integers (e.g. '0') or string (e.g. 'cuda:0') specifying which GPU "
-        "device(s) to use. Also supports lists of integers or strings, but underlying "
-        "computation only runs on a single GPU. 'cpu' will run on the CPU."
+        "A single integer or string specifying the GPU device to use (e.g., '0' or "
+        "'cuda:0' to select the zeroth GPU). A value of 'cpu' will run on the CPU. "
+        "The default is 'cpu'. Multiple GPU devices are not currently supported."
     ),
 )
 @click.option(

--- a/src/ttsim3d/models.py
+++ b/src/ttsim3d/models.py
@@ -123,6 +123,7 @@ class SimulatorConfig(BaseModel):
         if not _path_exists and not _is_default:
             e = f"Invalid MTF reference file: {v}. "
             e += "Please provide a valid path to an MTF reference file."
+            e += f"Or use a known reference: {list(DEFAULT_MTF_REFERENCES.keys())}"
             raise ValueError(e)
 
         if _is_default:

--- a/src/ttsim3d/models.py
+++ b/src/ttsim3d/models.py
@@ -39,6 +39,11 @@ ExcludedTensor = SkipJsonSchema[
 ]
 
 
+def included_mtf_references() -> list[str]:
+    """Returns a list of available MTF reference names."""
+    return list(DEFAULT_MTF_REFERENCES.keys())
+
+
 class SimulatorConfig(BaseModel):
     """Configuration for simulating a 3D volume.
 


### PR DESCRIPTION
Closes #26 by changing `--gpu-ids` to `--device` which only accepts in `str` type argument. Decoding of device is handled internally in the simulation function. Default is `"cpu"` which will run computation on the CPU rather than a GPU.