### PR TITLE
Bugfix for device handling for dose filter calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.3.0] -- 17 June 2025
+## [v0.4.0] -- 17 June 2025
 
 ### Modified
 
@@ -12,6 +12,8 @@
 ### Fixed
 
 - Fixes bug where pixel size was not being passed down to function simulating the dose weighting filter
+
+## [v0.3.0-v0.3.2] -- 16 May 2025
 
 ## [v0.2.1] -- 19 January 2025
 

--- a/src/ttsim3d/simulate3d.py
+++ b/src/ttsim3d/simulate3d.py
@@ -397,7 +397,8 @@ def calculate_simulation_dose_filter_3d(
         crit_exposure_bfactor=critical_bfactor,
         rfft=rfft,
         fftshift=fftshift,
-    ).to(device)
+        device=device,
+    )
 
     if modify_signal == "None":
         pass
@@ -513,7 +514,7 @@ def apply_simulation_filters(
             rfft=True,
             fftshift=False,
             device=device,
-        ).to(device)
+        )
         upsampled_volume_rfft *= mtf
 
     # Inverse FFT


### PR DESCRIPTION
See #35 and resolves #35.

Updated profiling shows that the dose filter calculation is happening on the correct GPU device.

<img width="1022" height="520" alt="image" src="https://github.com/user-attachments/assets/60c7f45c-358b-449d-a3c8-dbb422de833b" />
